### PR TITLE
adding sample interaction from cohort builder

### DIFF
--- a/R/mod_explore_page.R
+++ b/R/mod_explore_page.R
@@ -72,7 +72,7 @@ mod_explore_page_ui <- function(id){
 mod_explore_page_server <- function(input, output, session, specimens){
   ns <- session$ns
   
-  callModule(mod_gene_variant_server, "gene_variant_ui")
+  callModule(mod_gene_variant_server, "gene_variant_ui", specimens)
   callModule(mod_latent_variables_server, "latent_variables_ui_1", specimens)  
 }
     

--- a/R/mod_gene_var.R
+++ b/R/mod_gene_var.R
@@ -46,8 +46,10 @@ mod_gene_variant_server <- function(input, output, session, specimens){
   ns <- session$ns
   
   output$lollipop_plot <- shiny::renderPlot({
-    
+   
     tumor_sample_bc <- as.vector(kairos::jhu_tumor_file@data$Tumor_Sample_Barcode[kairos::jhu_tumor_file@clinical.data$specimenID %in% specimens()])
+    validate(need(length(tumor_sample_bc)>0, "No variant data found. Please modify your cohort."))
+
     file_with_specimen <- maftools::subsetMaf(kairos::jhu_tumor_file, tsb = c(tumor_sample_bc))
     
     maftools::lollipopPlot(

--- a/R/mod_gene_var.R
+++ b/R/mod_gene_var.R
@@ -42,10 +42,13 @@ mod_gene_variant_ui <- function(id){
 #' @export
 #' @keywords internal
 
-mod_gene_variant_server <- function(input, output, session){
+mod_gene_variant_server <- function(input, output, session, specimens){
   ns <- session$ns
   
   output$lollipop_plot <- shiny::renderPlot({
+    
+    tumor_sample_bc <- as.vector(kairos::jhu_tumor_file@data$Tumor_Sample_Barcode[kairos::jhu_tumor_file@clinical.data$specimenID %in% specimens()])
+    file_with_specimen <- maftools::subsetMaf(kairos::jhu_tumor_file, tsb = c(tumor_sample_bc))
     
     maftools::lollipopPlot(
       kairos::jhu_tumor_file,

--- a/man/mod_gene_variant.Rd
+++ b/man/mod_gene_variant.Rd
@@ -7,7 +7,7 @@
 \usage{
 mod_gene_variant_ui(id)
 
-mod_gene_variant_server(input, output, session)
+mod_gene_variant_server(input, output, session, specimens)
 }
 \arguments{
 \item{id}{shiny id}


### PR DESCRIPTION
-one caveat: projects a lollipopPlot even if it doesnt represent all the samples selected in the cohort. 

For eg. if cohort builder contains samples from 3 different studies, and there is gene var data from only study 1, the lollipopPlot plots data from study1 but does not give explicit indication that samples from study 2 and study 3 were not considered.

 We may want to add a disclaimer or restrict the plots so that the plots are representative of all samples (eg use `==` rather than `%in%`)